### PR TITLE
Optimize Julia version of ktruss

### DIFF
--- a/SubgraphIsomorphism/ktruss/code/julia/ktruss.jl
+++ b/SubgraphIsomorphism/ktruss/code/julia/ktruss.jl
@@ -1,15 +1,13 @@
-function calcx(E, m, n, k)
-    tmp = E.' * E
-    R = E * ( tmp - spdiagm( diag(tmp) ) )
-    r,c,v = findnz(R)
-    id = v .== 2
-    A = sparse( r[id], c[id], 1, m, n)
-    s = sum(A, 2)
-    x = s .< (k - 2)
-    return x, !x
+function calcx(Et, k)
+    n, m = size(Et)
+    tmp = Et*Et'
+    Rt = ( tmp - Diagonal( diag(tmp) ) )*Et
+    s = vec(sum(t -> t == 2, Rt, 1))
+    x = find(t -> t < (k - 2), s)
+    return x
 end
 
-function ktruss(inc_mtx_file, k)
+function ktruss(inc_mtx_file, k; time = true)
     if !isfile( inc_mtx_file )
         println("unable to open input file")
         return (-1)
@@ -17,20 +15,20 @@ function ktruss(inc_mtx_file, k)
 
     # load input data
     t_read_inc = @elapsed ii = readdlm( inc_mtx_file, '\t', Int64)
-    println("incidence matrix read time : ", t_read_inc)
+    time && println("incidence matrix read time : ", t_read_inc)
 
-    t_create_inc = @elapsed E = sparse( ii[:,1], ii[:,2], ii[:,3] )
-    println("sparse adj. matrix creation time : ", t_create_inc)
+    t_create_inc = @elapsed Et = sparse( ii[:,2], ii[:,1], ii[:,3] )
+    time && println("sparse adj. matrix creation time : ", t_create_inc)
 
-    tic()
-    m,n = size(E)
-    x, xc = calcx(E, m, n, k)
-    while sum(xc) != sum( any(E,2) )
-        E[find(x), :] = 0
-        x, xc = calcx(E, m, n, k)
+    time && tic()
+    m = size(Et, 2)
+    x = calcx(Et, k)
+    while (m - length(x)) != sum( any(Et,1) )
+        Et[:, x] = 0
+        x = calcx(Et, k)
     end
-    toc()
-    return E
+    time && toc()
+    return Et'
 end
 
 

--- a/SubgraphIsomorphism/ktruss/code/julia/ktruss.jl
+++ b/SubgraphIsomorphism/ktruss/code/julia/ktruss.jl
@@ -1,36 +1,35 @@
 function calcx(E, m, n, k)
-    tmp = E.'*E;
-    R = E * ( tmp - spdiagm( diag(tmp) ) );
-    r,c,v = findnz(R);
-    id = v.==2;
-    A = sparse( r[id], c[id], 1, m, n);
-    s = sum(A, 2);
-    x = s .< (k-2);    
-    return(x, !x);
+    tmp = E.' * E
+    R = E * ( tmp - spdiagm( diag(tmp) ) )
+    r,c,v = findnz(R)
+    id = v .== 2
+    A = sparse( r[id], c[id], 1, m, n)
+    s = sum(A, 2)
+    x = s .< (k - 2)
+    return x, !x
 end
 
 function ktruss(inc_mtx_file, k)
-    if ~isfile( inc_mtx_file )
-        println("unable to open input file");
-        return (-1);
+    if !isfile( inc_mtx_file )
+        println("unable to open input file")
+        return (-1)
     end
 
-    # load input data       
-    t_read_inc=@elapsed ii = readdlm( inc_mtx_file, '\t', Int64);
-    println("incidence matrix read time : ", t_read_inc);
+    # load input data
+    t_read_inc = @elapsed ii = readdlm( inc_mtx_file, '\t', Int64)
+    println("incidence matrix read time : ", t_read_inc)
 
-    t_create_inc=@elapsed E = sparse( ii[:,1], ii[:,2], ii[:,3] );
-    println("sparse adj. matrix creation time : ", t_create_inc);
+    t_create_inc = @elapsed E = sparse( ii[:,1], ii[:,2], ii[:,3] )
+    println("sparse adj. matrix creation time : ", t_create_inc)
 
-    #
-    tic();
-    m,n = size(E);
-    x, xc = calcx(E, m, n, k);
+    tic()
+    m,n = size(E)
+    x, xc = calcx(E, m, n, k)
     while sum(xc) != sum( any(E,2) )
         E[find(x), :] = 0
-        x, xc = calcx(E, m, n, k);
+        x, xc = calcx(E, m, n, k)
     end
-    
+    toc()
     return E
 end
 

--- a/SubgraphIsomorphism/ktruss/code/julia/runKtrussBenchmark.jl
+++ b/SubgraphIsomorphism/ktruss/code/julia/runKtrussBenchmark.jl
@@ -1,5 +1,5 @@
 
-include("ktruss.jl");
+include("ktruss.jl")
 
 inc_mtx_file = "../../../data/ktruss_example.tsv"
 
@@ -8,16 +8,16 @@ E_expected =  [1  1  0  0  0
                1  0  0  1  0
                0  0  1  1  0
                1  0  1  0  0
-               0  0  0  0  0];
+               0  0  0  0  0]
 
 
-@time E = ktruss(inc_mtx_file, 3);
+@time E = ktruss(inc_mtx_file, 3)
 
 if sum( E - E_expected ) > 0
-    println("Unable to verify results");
+    println("Unable to verify results")
 else
-    println("passed");
-    println(E);
+    println("passed")
+    println(E)
 end
 
 #######################################################

--- a/SubgraphIsomorphism/ktruss/code/julia/runKtrussBenchmark.jl
+++ b/SubgraphIsomorphism/ktruss/code/julia/runKtrussBenchmark.jl
@@ -11,6 +11,7 @@ E_expected =  [1  1  0  0  0
                0  0  0  0  0]
 
 
+E = ktruss(inc_mtx_file, 3, time = false)
 @time E = ktruss(inc_mtx_file, 3)
 
 if sum( E - E_expected ) > 0


### PR DESCRIPTION
Some of these optimizations are Julia specific but some of them are storage specific so they might also benefit the Matlab version. I've also cleaned the code for most Matlabisms. I've tried to keep the overall style of the code and avoided e.g. preallocating memory. The might be a significant saving in preallocation and it is a feature where Julia shines relative to Matlab so it might be worth doing. I timed this with Julia 0.6 which is in beta and will be released soon. It is slightly faster than Matlab for the small benchmark. Much of the time is spent in sparse matrix multiplication so it might also be worthwhile to consider https://github.com/JuliaSparse/MKLSparse.jl since it would give mulithreaded sparse matvec (and is probably what Matlab does) but I haven't tried that.