### PR TITLE
Update inferenceReLUvec.m

### DIFF
--- a/SparseDeepNeuralNetwork/matlab/inferenceReLUvec.m
+++ b/SparseDeepNeuralNetwork/matlab/inferenceReLUvec.m
@@ -4,23 +4,39 @@ function Y = inferenceReLUvec(W,bias,Y0);
 
   % Initialized feature vectors.
   Y = Y0;
+  octaveinfo=exist('octave_config_info');
+  % If using Matlab take advantage of sparse implementation
+  % of singleton expansion, otherwise for Octave use
+  % bsxfun
+  if(octaveinfo==0)
+    % Loop through each weight layer W{i}
+     for i=1:length(W)
   
-  % Loop through each weight layer W{i}
-  for i=1:length(W)
+        % Propagate through layer.
+        % Note: using graph convention of A(i,j) means connection from i *to* j,
+        % that requires *left* multiplication feature *row* vectors.
+        Z = Y*W{i};
+        b = bias{i};
+        % Apply bias to non-zero entries.
+        Y = Z + sparse(double(logical(Z)) .* b);
+        % Threshold negative values.
+        Y(Y < 0) = 0;
+     end
+  else
+     % Loop through each weight layer W{i}
+     for i=1:length(W)
   
-     % Propagate through layer.
-     % Note: using graph convention of A(i,j) means connection from i *to* j,
-     % that requires *left* multiplication feature *row* vectors.
-     Z = Y*W{i};
-     b = bias{i};
-
-     % Apply bias to non-zero entries.
-     Y = Z + (double(logical(Z)) .* b);
-     
-     % Threshold negative values.
-     Y(Y < 0) = 0;
-     
-  end
+        % Propagate through layer.
+        % Note: using graph convention of A(i,j) means connection from i *to* j,
+        % that requires *left* multiplication feature *row* vectors.
+        Z = Y*W{i};
+        b = bias{i};
+        % Apply bias to non-zero entries.
+        Y = Z + bsxfun(@(x,y) x .* y,double(logical(Z)),b);
+        % Threshold negative values.
+        Y(Y < 0) = 0;
+     end
+   endif
   
 return
 end
@@ -31,4 +47,3 @@ end
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % (c) <2019> Massachusetts Institute of Technology
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
-


### PR DESCRIPTION
Modified to also allow use of Octave which does not presently support .* operation on sparse arrays for singleton expansions. Follows hints from:
https://stackoverflow.com/questions/2246579/how-do-i-detect-if-im-running-matlab-or-octave
https://stackoverflow.com/questions/12951453/in-matlab-when-is-it-optimal-to-use-bsxfun
http://octave.1599824.n4.nabble.com/Use-of-bsxfun-td3832688.html